### PR TITLE
Add Marvin function to provide current system name only.

### DIFF
--- a/Marvin/SystemData.php
+++ b/Marvin/SystemData.php
@@ -430,3 +430,18 @@ if (isset($_GET["rm"]))
 	((is_null($___mysqli_res = mysqli_close($link))) ? false : $___mysqli_res);
 	exit;
 }
+
+if (isset($_GET["sys_short"]))
+{
+
+	$va_text .= "unknown";
+
+	if (!empty($curSys["name"]))
+	{
+		$va_text = $curSys["name"];
+	}
+
+	echo tts_override($va_text);
+
+	exit;
+}


### PR DESCRIPTION
via SystemData.php?sys_short

Example:
When in "California Sector LX-T b3-0", sys_short will provide the value:
"California Sector LX tack T b tree tack zero"

I am currently using this in my local branch.
