### PR TITLE
Two small quality of life improvements for mobile users

### DIFF
--- a/add/coord.php
+++ b/add/coord.php
@@ -234,7 +234,7 @@ else
 					echo '<tr><td class="dark" style="text-align:right"><input class="textbox" type="hidden" id="' . $i . '" name="reference_' . $i . '" value="' . $ref_rname . '" />
 					<input class="textbox" type="hidden" name="reference_' . $i . '_coordinates" value="' . $ref_coordinates . '" /><a href="javascript:void(0)" title="Copy to clipboard"><img class="btn" src="/style/img/clipboard.png" alt="Copy" data-clipboard-text="' . $ref_rname . '" /></a>
 					<strong>' . $ref_rname . '</strong></td><td class="dark">
-					<input class="textbox" type="number" id="ref_' . $i . '_dist" name="reference_' . $i . '_distance" value="' . $ref[$i]["distance"] . '" placeholder="1234.56" style="width:100px" /><br /><span class="settings_info" style="font-size:11px">No commas or spaces</span></td></tr>';
+					<input class="textbox" type="number" autocomplete="off" id="ref_' . $i . '_dist" name="reference_' . $i . '_distance" value="' . $ref[$i]["distance"] . '" placeholder="1234.56" style="width:100px" /><br /><span class="settings_info" style="font-size:11px">No commas or spaces</span></td></tr>';
 					$i++;
 				}
 				?>

--- a/add/coord.php
+++ b/add/coord.php
@@ -234,7 +234,7 @@ else
 					echo '<tr><td class="dark" style="text-align:right"><input class="textbox" type="hidden" id="' . $i . '" name="reference_' . $i . '" value="' . $ref_rname . '" />
 					<input class="textbox" type="hidden" name="reference_' . $i . '_coordinates" value="' . $ref_coordinates . '" /><a href="javascript:void(0)" title="Copy to clipboard"><img class="btn" src="/style/img/clipboard.png" alt="Copy" data-clipboard-text="' . $ref_rname . '" /></a>
 					<strong>' . $ref_rname . '</strong></td><td class="dark">
-					<input class="textbox" type="text" id="ref_' . $i . '_dist" name="reference_' . $i . '_distance" value="' . $ref[$i]["distance"] . '" placeholder="1234.56" style="width:100px" /><br /><span class="settings_info" style="font-size:11px">No commas or spaces</span></td></tr>';
+					<input class="textbox" type="number" id="ref_' . $i . '_dist" name="reference_' . $i . '_distance" value="' . $ref[$i]["distance"] . '" placeholder="1234.56" style="width:100px" /><br /><span class="settings_info" style="font-size:11px">No commas or spaces</span></td></tr>';
 					$i++;
 				}
 				?>

--- a/style/footer.php
+++ b/style/footer.php
@@ -85,9 +85,9 @@
 									<input class="textbox" type="text" name="from_system_name" placeholder="From system" id="system_2" style="width:97%" oninput="showResult(this.value, '2')" />
 								</td>
 								<td class="dark">
-									<input class="textbox" type="text" name="from_coor[]" placeholder="From x.x" id="coordsx_2" />
-									<input class="textbox" type="text" name="from_coor[]" placeholder="From y.y" id="coordsy_2" />
-									<input class="textbox" type="text" name="from_coor[]" placeholder="From z.z" id="coordsz_2" />
+									<input class="textbox" type="number" name="from_coor[]" placeholder="From x.x" id="coordsx_2" />
+									<input class="textbox" type="number" name="from_coor[]" placeholder="From y.y" id="coordsy_2" />
+									<input class="textbox" type="number" name="from_coor[]" placeholder="From z.z" id="coordsz_2" />
 								</td>
 							</tr>
 							<tr>
@@ -95,9 +95,9 @@
 									<input class="textbox" type="text" name="to_system_name" placeholder="To system" id="system_6" style="width:97%" oninput="showResult(this.value, '6')" />
 								</td>
 								<td class="dark">
-									<input class="textbox" type="text" name="to_coor[]" placeholder="To x.x" id="coordsx_6" />
-									<input class="textbox" type="text" name="to_coor[]" placeholder="To y.y" id="coordsy_6" />
-									<input class="textbox" type="text" name="to_coor[]" placeholder="To z.z" id="coordsz_6" />
+									<input class="textbox" type="number" name="to_coor[]" placeholder="To x.x" id="coordsx_6" />
+									<input class="textbox" type="number" name="to_coor[]" placeholder="To y.y" id="coordsy_6" />
+									<input class="textbox" type="number" name="to_coor[]" placeholder="To z.z" id="coordsz_6" />
 								</td>
 							</tr>
 							<tr>


### PR DESCRIPTION
These are tiny changes but make a world of difference when using the site on a phone.

The add system co-ords (and calculate distances co-ords) text boxes are set as type text. The first commit changes them to type number, so the number keypad is displayed instead of the text keyboard.

In addition, certain browsers such as Chrome try to be helpful and pop-up auto-complete suggestions on the co-ords boxes. This is not likely to be useful on the add unknown co-ordinates page as the co-ordinates are unknown! :smile: The second commit here disables the auto-complete, reducing clutter on the page.

Before screenshot: 
http://i.imgur.com/5F2Ziv1.png

After screenshot:
http://i.imgur.com/dRzVdSA.png

Much nicer!

This also has the bonus side effect that you can't put text, spaces or commas into the boxes either.
